### PR TITLE
Use the first primary source if the game is unknown

### DIFF
--- a/src/installerncc.cpp
+++ b/src/installerncc.cpp
@@ -98,7 +98,7 @@ QString InstallerNCC::description() const
 
 VersionInfo InstallerNCC::version() const
 {
-  return VersionInfo(1, 1, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 2, 0, VersionInfo::RELEASE_FINAL);
 }
 
 bool InstallerNCC::isActive() const
@@ -342,7 +342,13 @@ IPluginInstaller::EInstallResult InstallerNCC::install(GuessedValue<QString> &mo
   modName = QInputDialog::getText(parentWidget(), tr("Confirm Mod Name"), tr("Desired mod name:"), QLineEdit::Normal, modName, &ok);
 
   const IPluginGame *game = m_MOInfo->getGame(gameName);
-  if (game == nullptr) game = m_MOInfo->managedGame();
+  if (game == nullptr) {
+    game = m_MOInfo->managedGame();
+    QStringList sources = game->primarySources();
+    if (sources.size()) {
+      game = m_MOInfo->getGame(sources.at(0));
+    }
+  }
 
   if (!ok)
     return RESULT_CANCELED;


### PR DESCRIPTION
This helps the SkyrimVR, Fallout4VR, and TTW plugins by preventing
an invalid NCC game name from being used when the metadata is not
present.

I've tested this with TTW.  It reduces the need for the user to query info on TTW mods imported into MO2 as they'll just be assumed to be FalloutNV mods.  It also helps fix the issue where "bundled" mods don't have their metadata copied for the extracted mods, as again they'll be assumed to be FalloutNV mods.  

I've also tested this with Skyrim, which doesn't have any primary sources defined, and it works as intended.  