### PR TITLE
Delete Temp\NMMCLI before running the installer

### DIFF
--- a/src/installer_ncc_en.ts
+++ b/src/installer_ncc_en.ts
@@ -9,77 +9,77 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="276"/>
+        <location filename="installerncc.cpp" line="280"/>
         <source>failed to start %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="280"/>
+        <location filename="installerncc.cpp" line="284"/>
         <source>Running external installer.
 Based on Nexus Mod Manager by Black Tree Gaming Ltd.
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="282"/>
+        <location filename="installerncc.cpp" line="286"/>
         <source>Force Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="308"/>
+        <location filename="installerncc.cpp" line="312"/>
         <source>Confirm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="331"/>
+        <location filename="installerncc.cpp" line="335"/>
         <source>installation failed (errorcode %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="342"/>
+        <location filename="installerncc.cpp" line="346"/>
         <source>Confirm Mod Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="342"/>
+        <location filename="installerncc.cpp" line="346"/>
         <source>Desired mod name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="453"/>
+        <location filename="installerncc.cpp" line="457"/>
         <source>NCC is not installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="455"/>
+        <location filename="installerncc.cpp" line="459"/>
         <source>NCC Version may be incompatible.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="457"/>
+        <location filename="installerncc.cpp" line="461"/>
         <source>.NET 4.6 or greater is required.</source>
         <oldsource>dotNet is not installed or outdated.</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="459"/>
-        <location filename="installerncc.cpp" line="477"/>
-        <location filename="installerncc.cpp" line="488"/>
+        <location filename="installerncc.cpp" line="463"/>
+        <location filename="installerncc.cpp" line="481"/>
+        <location filename="installerncc.cpp" line="492"/>
         <source>invalid problem key %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="467"/>
+        <location filename="installerncc.cpp" line="471"/>
         <source>NCC is not installed. You won&apos;t be able to install some scripted mod-installers. Get NCC from &lt;a href=&quot;http://www.nexusmods.com/skyrim/mods/1334&quot;&gt;the MO page on nexus&lt;/a&gt;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="470"/>
+        <location filename="installerncc.cpp" line="474"/>
         <source>NCC version may be incompatible, expected version 0.%1.x.x.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="installerncc.cpp" line="473"/>
+        <location filename="installerncc.cpp" line="477"/>
         <source>&lt;li&gt;.NET version 4.6 or greater is required to use NCC. Get it from here: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;&lt;/li&gt;</source>
         <oldsource>&lt;li&gt;dotNet is not installed or the wrong version. This is required to use NCC. Get it from here: &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;&lt;/li&gt;</oldsource>
         <translation type="unfinished"></translation>

--- a/src/installerncc.cpp
+++ b/src/installerncc.cpp
@@ -98,7 +98,7 @@ QString InstallerNCC::description() const
 
 VersionInfo InstallerNCC::version() const
 {
-  return VersionInfo(1, 3, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 4, 0, VersionInfo::RELEASE_FINAL);
 }
 
 bool InstallerNCC::isActive() const
@@ -223,6 +223,10 @@ IPluginInstaller::EInstallResult InstallerNCC::invokeNCC(IModInterface *modInter
       seString = std::wstring() + L"-se \"" + seVersion + L"\"";
     }
   }
+
+  // NCC doesn't always clean up the TEMP folder correctly so this force
+  // deletes it before every install
+  shellDelete(QStringList() << QDir::temp().absoluteFilePath("NMMCLI"));
 
   _snwprintf(parameters, sizeof(parameters), L"-g %ls -p \"%ls\" -gd \"%ls\" -d \"%ls\" %ls -i \"%ls\" \"%ls\"",
              game->gameShortName().toStdWString().c_str(),


### PR DESCRIPTION
This hopefully fixes a long standing issue where NCC installs fail due to there already being files in the Temp\NMMCLI folder.